### PR TITLE
Revert "Reset stepsize controller after performing registration"

### DIFF
--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -262,8 +262,6 @@ class GeodesicShooting:
         opt['time'] = elapsed_time
         opt['reason_registration_ended'] = reason_registration_ended
 
-        stepsize_controller.reset()
-
         if return_all:
             return opt
         return initial_velocity_field

--- a/geodesic_shooting/landmark_shooting.py
+++ b/geodesic_shooting/landmark_shooting.py
@@ -240,8 +240,6 @@ class LandmarkShooting:
         opt['time'] = elapsed_time
         opt['reason_registration_ended'] = reason_registration_ended
 
-        stepsize_controller.reset()
-
         if return_all:
             return opt
         return res['x'].reshape((-1, self.dim))

--- a/geodesic_shooting/lddmm.py
+++ b/geodesic_shooting/lddmm.py
@@ -270,8 +270,6 @@ class LDDMM:
         opt['time'] = elapsed_time
         opt['reason_registration_ended'] = reason_registration_ended
 
-        stepsize_controller.reset()
-
         if return_all:
             return opt
         return velocity_fields

--- a/geodesic_shooting/utils/optim.py
+++ b/geodesic_shooting/utils/optim.py
@@ -128,14 +128,9 @@ class BaseStepsizeController:
         self.line_search = line_search
 
         self.log_frequency = log_frequency
-
-        self.reset()
+        self.number_iterations_without_logging = 0
 
         self.logger = getLogger('stepsize_controller', level=log_level)
-
-    def reset(self):
-        """Function to reset internal parameters of the stepsize controller."""
-        self.number_iterations_without_logging = 0
 
     def _check_parameters(self, parameters_line_search):
         """Function to check whether the parameters given to the stepsize controller can fit the
@@ -324,18 +319,13 @@ class PatientStepsizeController(BaseStepsizeController):
         self.line_search = line_search
 
         self.patience = patience
-
-        self.log_frequency = log_frequency
-
-        self.reset()
-
-        self.logger = getLogger('stepsize_controller', level=log_level)
-
-    def reset(self):
-        """Function to reset internal parameters of the stepsize controller."""
         self.maximal_reduced_stepsize = None
         self.number_iterations_without_changing_stepsize = 0
+
+        self.log_frequency = log_frequency
         self.number_iterations_without_logging = 0
+
+        self.logger = getLogger('stepsize_controller', level=log_level)
 
     def update(self, parameters_line_search, current_stepsize):
         """Function that updates the minimal and maximal stepsize of the line search algorithm.


### PR DESCRIPTION
Reverts HenKlei/geodesic-shooting#26

These changes were not necessary, since the stepsize controller is created in the `register` method anyway and not globally available.