### PR TITLE
Match unlabeled landmarks

### DIFF
--- a/examples/landmark_shooting/2d_example.py
+++ b/examples/landmark_shooting/2d_example.py
@@ -65,6 +65,5 @@ if __name__ == "__main__":
     print(f"Input: {input_landmarks}")
     print(f"Target: {target_landmarks}")
     print(f"Result: {registered_landmarks}")
-    rel_error = (np.linalg.norm(target_landmarks - registered_landmarks)
-                 / np.linalg.norm(target_landmarks))
-    print(f"Relative norm of difference: {rel_error}")
+    error = np.linalg.norm(target_landmarks - registered_landmarks)
+    print(f"Norm of difference: {error}")

--- a/examples/landmark_shooting/2d_example_unlabeled.py
+++ b/examples/landmark_shooting/2d_example_unlabeled.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     print(f"Matching function value for target landmarks: {compute_matching_function(target_landmarks)}")
 
     # perform the registration using landmark shooting algorithm
-    gs = geodesic_shooting.LandmarkShooting(kwargs_kernel={'sigma': .1})
+    gs = geodesic_shooting.LandmarkShooting(kwargs_kernel={'sigma': 1.})
     result = gs.register(input_landmarks, target_landmarks, sigma=0.1, return_all=True,
                          landmarks_labeled=False, kwargs_kernel_dist={'sigma': 1.})
     final_momenta = result['initial_momenta']

--- a/examples/landmark_shooting/2d_example_unlabeled.py
+++ b/examples/landmark_shooting/2d_example_unlabeled.py
@@ -5,24 +5,42 @@ import geodesic_shooting
 
 from geodesic_shooting.utils.visualization import (animate_landmark_trajectories,
                                                    plot_initial_momenta_and_landmarks,
-                                                   plot_landmark_matchings,
-                                                   plot_landmark_trajectories, animate_warpgrids)
+                                                   plot_landmarks, plot_landmark_trajectories)
 from geodesic_shooting.core import ScalarFunction
 
 
 if __name__ == "__main__":
     # define landmark positions
-    input_landmarks = np.array([[5., 3.], [4., 2.], [1., 0.], [2., 3.]])
-    target_landmarks = np.array([[6., 2.], [5., 1.], [1., -1.], [2.5, 2.]])
+    input_landmarks = np.array([[4., -.25], [3., 5./3.], [4., 7./3.], [5., 3.]])
+    target_landmarks = np.array([[3.4, -.25], [4., .5], [5., 1.25], [6., 2.]])
+
+    from geodesic_shooting.utils.kernels import GaussianKernel
+    kernel_dist = GaussianKernel(sigma=1., scalar=True)
+
+    def compute_matching_function(positions):
+        reshaped_positions = positions.reshape(input_landmarks.shape)
+        dist = 0.
+        for p in reshaped_positions:
+            for q in reshaped_positions:
+                dist += kernel_dist(p, q)
+            for t in target_landmarks:
+                dist -= 2. * kernel_dist(p, t)
+        for t in target_landmarks:
+            for s in target_landmarks:
+                dist += kernel_dist(t, s)
+        return dist
+
+    print(f"Matching function value for target landmarks: {compute_matching_function(target_landmarks)}")
 
     # perform the registration using landmark shooting algorithm
-    gs = geodesic_shooting.LandmarkShooting(kwargs_kernel={'sigma': 2.})
-    result = gs.register(input_landmarks, target_landmarks, sigma=0.1, return_all=True, landmarks_labeled=True)
+    gs = geodesic_shooting.LandmarkShooting(kwargs_kernel={'sigma': .1})
+    result = gs.register(input_landmarks, target_landmarks, sigma=0.1, return_all=True,
+                         landmarks_labeled=False, kwargs_kernel_dist={'sigma': 1.})
     final_momenta = result['initial_momenta']
     registered_landmarks = result['registered_landmarks']
 
     # plot results
-    plot_landmark_matchings(input_landmarks, target_landmarks, registered_landmarks)
+    plot_landmarks(input_landmarks, target_landmarks, registered_landmarks)
 
     plot_initial_momenta_and_landmarks(final_momenta.flatten(), registered_landmarks.flatten(),
                                        min_x=0., max_x=7., min_y=-2., max_y=4.)
@@ -65,6 +83,4 @@ if __name__ == "__main__":
     print(f"Input: {input_landmarks}")
     print(f"Target: {target_landmarks}")
     print(f"Result: {registered_landmarks}")
-    rel_error = (np.linalg.norm(target_landmarks - registered_landmarks)
-                 / np.linalg.norm(target_landmarks))
-    print(f"Relative norm of difference: {rel_error}")
+    print(f"Matching function value for registered landmarks: {compute_matching_function(registered_landmarks)}")

--- a/geodesic_shooting/utils/kernels.py
+++ b/geodesic_shooting/utils/kernels.py
@@ -9,29 +9,41 @@ class Kernel:
 
 class GaussianKernel(Kernel):
     """Class that implements a Gaussian (matrix-valued, diagonal) kernel."""
-    def __init__(self, sigma=1./np.sqrt(2.)):
+    def __init__(self, scalar=False, sigma=1./np.sqrt(2.)):
         """Constructor.
 
         Parameters
         ----------
+        scalar
+            If `True`, a scalar-valued kernel is returned, otherwise a matrix-valued,
+            diagonal kernel.
         sigma
             Scaling parameter for the Gaussian bell curve.
         """
         super().__init__()
         assert sigma > 0
+        self.scalar = scalar
         self.sigma = sigma
 
     def __call__(self, x, y):
         assert x.ndim == 1
         assert x.shape == y.shape
-        return np.exp(-np.linalg.norm(x-y)**2 / (self.sigma**2)) * np.eye(x.shape[0]) / (self.sigma**2)
+        res = np.exp(-np.linalg.norm(x-y)**2 / (self.sigma**2)) / (self.sigma**2)
+        if self.scalar:
+            return res
+        else:
+            return res * np.eye(x.shape[0])
 
     def derivative_1(self, x, y, i):
         """Derivative of kernel with respect to i-th component of x."""
         assert x.ndim == 1
         assert x.shape == y.shape
         assert 0 <= i < x.shape[0]
-        return 2. * (y[i] - x[i]) / (self.sigma**4) * self(x, y)[0][0]
+        res = 2. * (y[i] - x[i]) / self.sigma**4
+        if self.scalar:
+            return res * self(x, y)
+        else:
+            return res * self(x, y)[0][0]
 
     def derivative_2(self, x, y, i):
         """Derivative of kernel with respect to i-th component of y."""

--- a/geodesic_shooting/utils/kernels.py
+++ b/geodesic_shooting/utils/kernels.py
@@ -55,11 +55,14 @@ class GaussianKernel(Kernel):
 
 class RationalQuadraticKernel(Kernel):
     """Class that implements a rational quadratic (matrix-valued, diagonal) kernel."""
-    def __init__(self, sigma=1./np.sqrt(2.), alpha=1):
+    def __init__(self, scalar=False, sigma=1./np.sqrt(2.), alpha=1):
         """Constructor.
 
         Parameters
         ----------
+        scalar
+            If `True`, a scalar-valued kernel is returned, otherwise a matrix-valued,
+            diagonal kernel.
         sigma
             Scaling parameter for the squared norm.
         alpha
@@ -68,13 +71,18 @@ class RationalQuadraticKernel(Kernel):
         super().__init__()
         assert sigma > 0
         assert alpha > 0
+        self.scalar = scalar
         self.sigma = sigma
         self.alpha = alpha
 
     def __call__(self, x, y):
         assert x.ndim == 1
         assert x.shape == y.shape
-        return np.eye(x.shape[0]) / ((1. + np.linalg.norm(x-y)**2 / (self.sigma**2))**self.alpha)
+        res = 1. / ((1. + np.linalg.norm(x-y)**2 / (self.sigma**2))**self.alpha)
+        if self.scalar:
+            return res
+        else:
+            return res * np.eye(x.shape[0])
 
     def derivative_1(self, x, y, i):
         """Derivative of kernel with respect to i-th component of x."""

--- a/geodesic_shooting/utils/visualization.py
+++ b/geodesic_shooting/utils/visualization.py
@@ -286,6 +286,58 @@ def plot_landmark_matchings(input_landmarks, target_landmarks, registered_landma
     return axis
 
 
+def plot_landmarks(input_landmarks, target_landmarks, registered_landmarks,
+                   title='', axis=None, landmark_size=50):
+    """Plot the results of the matching of landmarks.
+
+    Parameters
+    ----------
+    input_landmarks
+        Positions of the input landmarks.
+    target_landmarks
+        Positions of the target landmarks.
+    registered_landmarks
+        Positions of the registered landmarks.
+    title
+        Title of the plot.
+    axis
+        If not `None`, the function is plotted on the provided axis.
+    landmark_size
+        Size of the landmarks.
+
+    Returns
+    -------
+    The created plot.
+    """
+    assert input_landmarks.ndim == 2
+    assert input_landmarks.shape == registered_landmarks.shape
+    assert target_landmarks.ndim == 2
+
+    created_figure = False
+    if not axis:
+        created_figure = True
+        fig = plt.figure()
+        axis = fig.add_subplot(1, 1, 1)
+
+    axis.set_aspect('equal')
+    axis.set_title(title)
+
+    colors = [f'C{i}' for i in range(len(input_landmarks))]
+
+    axis.scatter(input_landmarks[:, 0], input_landmarks[:, 1],
+                 s=landmark_size, color=colors, marker='o', label="Input landmark")
+    axis.scatter(target_landmarks[:, 0], target_landmarks[:, 1],
+                 s=landmark_size, marker='*', label="Target landmark")
+    axis.scatter(registered_landmarks[:, 0], registered_landmarks[:, 1],
+                 s=landmark_size, color=colors, marker='s', label="Registered landmark")
+
+    plt.legend()
+
+    if created_figure:
+        return fig, axis
+    return axis
+
+
 def animate_warpgrids(time_evolution_warp, min_x=-1., max_x=1., min_y=-1., max_y=1.,
                       title='', interval=1, show_axis=True):
     """Animate the trajectories of the landmarks.

--- a/tests/test_landmark_matching.py
+++ b/tests/test_landmark_matching.py
@@ -36,7 +36,7 @@ def test_landmark_matching():
 
     gs = geodesic_shooting.LandmarkShooting()
     result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
-                         landmarks_labeled=False,)
+                         landmarks_labeled=False)
     registered_landmarks = result['registered_landmarks']
     dist = compute_average_distance(target_landmarks, registered_landmarks)
     assert dist < 1e-3
@@ -50,4 +50,4 @@ def test_landmark_matching():
                          landmarks_labeled=True)
     registered_landmarks = result['registered_landmarks']
     dist = compute_average_distance(target_landmarks, registered_landmarks)
-    assert dist < 5e-2
+    assert dist < 1e-3

--- a/tests/test_landmark_matching.py
+++ b/tests/test_landmark_matching.py
@@ -4,6 +4,13 @@ import geodesic_shooting
 
 
 def test_landmark_matching():
+    def compute_average_distance(target_landmarks, registered_landmarks):
+        dist = 0.
+        for x, y in zip(registered_landmarks, target_landmarks):
+            dist += np.linalg.norm(x - y)
+        dist /= registered_landmarks.shape[0]
+        return dist
+
     input_landmarks = np.array([[5., 3.]])
     target_landmarks = np.array([[6., 2.]])
 
@@ -11,8 +18,8 @@ def test_landmark_matching():
     result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
                          landmarks_labeled=True)
     registered_landmarks = result['registered_landmarks']
-
-    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-5
+    dist = compute_average_distance(target_landmarks, registered_landmarks)
+    assert dist < 1e-5
 
     input_landmarks = np.array([[5., 3.], [1., 1.]])
     target_landmarks = np.array([[6., 2.], [0., 0.]])
@@ -21,8 +28,8 @@ def test_landmark_matching():
     result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
                          landmarks_labeled=True)
     registered_landmarks = result['registered_landmarks']
-
-    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-5
+    dist = compute_average_distance(target_landmarks, registered_landmarks)
+    assert dist < 1e-5
 
     input_landmarks = np.array([[5., 3.], [1., 1.]])
     target_landmarks = np.array([[6., 2.], [0., 0.]])
@@ -31,8 +38,8 @@ def test_landmark_matching():
     result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
                          landmarks_labeled=False,)
     registered_landmarks = result['registered_landmarks']
-
-    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-3
+    dist = compute_average_distance(target_landmarks, registered_landmarks)
+    assert dist < 1e-3
 
     input_landmarks = np.array([[5., 3.], [4., 2.], [1., 0.], [2., 3.]])
     target_landmarks = np.array([[6., 2.], [5., 1.], [1., -1.], [2.5, 2.]])
@@ -42,5 +49,5 @@ def test_landmark_matching():
     result = gs.register(input_landmarks, target_landmarks, sigma=0.1, return_all=True,
                          landmarks_labeled=True)
     registered_landmarks = result['registered_landmarks']
-
-    assert np.linalg.norm(registered_landmarks - target_landmarks) < 5e-2
+    dist = compute_average_distance(target_landmarks, registered_landmarks)
+    assert dist < 5e-2

--- a/tests/test_landmark_matching.py
+++ b/tests/test_landmark_matching.py
@@ -33,3 +33,14 @@ def test_landmark_matching():
     registered_landmarks = result['registered_landmarks']
 
     assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-3
+
+    input_landmarks = np.array([[5., 3.], [4., 2.], [1., 0.], [2., 3.]])
+    target_landmarks = np.array([[6., 2.], [5., 1.], [1., -1.], [2.5, 2.]])
+
+    # perform the registration using landmark shooting algorithm
+    gs = geodesic_shooting.LandmarkShooting(kwargs_kernel={'sigma': 2.})
+    result = gs.register(input_landmarks, target_landmarks, sigma=0.1, return_all=True,
+                         landmarks_labeled=True)
+    registered_landmarks = result['registered_landmarks']
+
+    assert np.linalg.norm(registered_landmarks - target_landmarks) < 5e-2

--- a/tests/test_landmark_matching.py
+++ b/tests/test_landmark_matching.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+import geodesic_shooting
+
+
+def test_landmark_matching():
+    input_landmarks = np.array([[5., 3.]])
+    target_landmarks = np.array([[6., 2.]])
+
+    gs = geodesic_shooting.LandmarkShooting()
+    result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
+                         landmarks_labeled=True)
+    registered_landmarks = result['registered_landmarks']
+
+    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-5
+
+    input_landmarks = np.array([[5., 3.], [1., 1.]])
+    target_landmarks = np.array([[6., 2.], [0., 0.]])
+
+    gs = geodesic_shooting.LandmarkShooting()
+    result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
+                         landmarks_labeled=True)
+    registered_landmarks = result['registered_landmarks']
+
+    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-5
+
+    input_landmarks = np.array([[5., 3.], [1., 1.]])
+    target_landmarks = np.array([[6., 2.], [0., 0.]])
+
+    gs = geodesic_shooting.LandmarkShooting()
+    result = gs.register(input_landmarks, target_landmarks, sigma=0.05, return_all=True,
+                         landmarks_labeled=False,)
+    registered_landmarks = result['registered_landmarks']
+
+    assert np.linalg.norm(registered_landmarks - target_landmarks) < 1e-3


### PR DESCRIPTION
By treating unlabeled landmarks as dirac measures, it is possible to perform matching via geodesic landmark shooting also for unlabeled landmark sets.