### PR TITLE
Homogeneous Dirichlet boundary conditions

### DIFF
--- a/examples/geodesic_shooting/1d_example.py
+++ b/examples/geodesic_shooting/1d_example.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     target[2*N//5:3*N//5] = 1
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=4., exponent=2)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
     plot_registration_results(result)

--- a/examples/geodesic_shooting/2d_example.py
+++ b/examples/geodesic_shooting/2d_example.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     target[2*N//5:3*N//5, M//5:2*M//5] = 1
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=1, exponent=3)
-    result = gs.register(template, target, sigma=0.1, return_all=True)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
+    result = gs.register(template, target, sigma=0.01, return_all=True)
 
     plot_registration_results(result)

--- a/examples/geodesic_shooting/3d_example.py
+++ b/examples/geodesic_shooting/3d_example.py
@@ -9,13 +9,13 @@ if __name__ == "__main__":
     shape = (10, 10, 10)
     template = np.zeros(shape)
     target = np.zeros(shape)
-    template[shape[0]//5:2*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:2*shape[2]//5] = 1
-    target[shape[0]//5:3*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:3*shape[2]//5] = 1
+    template[2*shape[0]//5:3*shape[0]//5, 2*shape[1]//5:3*shape[1]//5, 2*shape[2]//5:3*shape[2]//5] = 1
+    target[2*shape[0]//5:3*shape[0]//5, 3*shape[1]//5:4*shape[1]//5, 2*shape[2]//5:3*shape[2]//5] = 1
     template = ScalarFunction(data=template)
     target = ScalarFunction(data=target)
 
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
-    result = gs.register(template, target, sigma=0.01, return_all=True)
+    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD')
 
     plot_registration_results(result)

--- a/examples/geodesic_shooting/3d_example.py
+++ b/examples/geodesic_shooting/3d_example.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     target = ScalarFunction(data=target)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=5., exponent=2)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
     plot_registration_results(result)

--- a/examples/geodesic_shooting/circle_scaling_example.py
+++ b/examples/geodesic_shooting/circle_scaling_example.py
@@ -11,10 +11,9 @@ if __name__ == "__main__":
     target = make_circle((64, 64), np.array([32, 32]), 20)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, fourier=False)
-    gs.regularizer.init_matrices(target.spatial_shape)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
     result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD',
-                         optimizer_options={'disp': True, 'maxiter': 20})
+                         optimizer_options={'disp': True, 'maxiter': 50})
 
     plot_registration_results(result)
     gs.regularizer.cauchy_navier(result['initial_vector_field']).plot(title='Cauchy Navier operator applied '

--- a/examples/geodesic_shooting/circle_scaling_example.py
+++ b/examples/geodesic_shooting/circle_scaling_example.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
 
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
-    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD',
-                         optimizer_options={'disp': True, 'maxiter': 50})
+    result = gs.register(template, target, sigma=0.01, return_all=True,
+                         optimizer_options={'disp': True, 'maxiter': 20})
 
     plot_registration_results(result)
     gs.regularizer.cauchy_navier(result['initial_vector_field']).plot(title='Cauchy Navier operator applied '

--- a/examples/geodesic_shooting/circle_scaling_example.py
+++ b/examples/geodesic_shooting/circle_scaling_example.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     target = make_circle((64, 64), np.array([32, 32]), 20)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.05, exponent=1, gamma=5.)
     result = gs.register(template, target, sigma=0.01, return_all=True,
                          optimizer_options={'disp': True, 'maxiter': 20})
 

--- a/examples/geodesic_shooting/circle_scaling_example.py
+++ b/examples/geodesic_shooting/circle_scaling_example.py
@@ -13,7 +13,8 @@ if __name__ == "__main__":
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, fourier=False)
     gs.regularizer.init_matrices(target.spatial_shape)
-    result = gs.register(template, target, sigma=0.01, return_all=True, optimizer_options={'disp': True, 'maxiter': 20})
+    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD',
+                         optimizer_options={'disp': True, 'maxiter': 20})
 
     plot_registration_results(result)
     gs.regularizer.cauchy_navier(result['initial_vector_field']).plot(title='Cauchy Navier operator applied '

--- a/examples/geodesic_shooting/circle_scaling_example.py
+++ b/examples/geodesic_shooting/circle_scaling_example.py
@@ -11,7 +11,8 @@ if __name__ == "__main__":
     target = make_circle((64, 64), np.array([32, 32]), 20)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, fourier=False)
+    gs.regularizer.init_matrices(target.spatial_shape)
     result = gs.register(template, target, sigma=0.01, return_all=True, optimizer_options={'disp': True, 'maxiter': 20})
 
     plot_registration_results(result)

--- a/examples/geodesic_shooting/circle_to_square_example.py
+++ b/examples/geodesic_shooting/circle_to_square_example.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     target = make_square((64, 64), np.array([32, 32]), 40)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, gamma=5.)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1, gamma=5.)
     result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD',
                          optimizer_options={'maxiter': 50, 'grad_norm_tol': 1e-3})
 

--- a/examples/geodesic_shooting/translation_example.py
+++ b/examples/geodesic_shooting/translation_example.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
               + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1, gamma=1.)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
     result['initial_vector_field'].save_tikz('initial_vector_field_translation.tex',

--- a/examples/geodesic_shooting/translation_example.py
+++ b/examples/geodesic_shooting/translation_example.py
@@ -7,14 +7,14 @@ from geodesic_shooting.utils.summary import plot_registration_results, save_plot
 
 if __name__ == "__main__":
     # create images
-    template = (make_circle((64, 64), np.array([25, 40]), 18) * 0.2
-              + make_circle((64, 64), np.array([25, 40]), 15) * 0.8)
-    target = (make_circle((64, 64), np.array([40, 25]), 18) * 0.2
-              + make_circle((64, 64), np.array([40, 25]), 15) * 0.8)
+    template = (make_circle((64, 64), np.array([25, 35]), 15) * 0.2
+              + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
+    target = (make_circle((64, 64), np.array([35, 25]), 15) * 0.2
+              + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=1., exponent=2)
-    result = gs.register(template, target, sigma=0.1, return_all=True)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2, gamma=1.)
+    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD')
 
     result['initial_vector_field'].save_tikz('initial_vector_field_translation.tex',
                                              title="Initial vector field translation",

--- a/examples/geodesic_shooting/translation_example.py
+++ b/examples/geodesic_shooting/translation_example.py
@@ -8,13 +8,13 @@ from geodesic_shooting.utils.summary import plot_registration_results, save_plot
 if __name__ == "__main__":
     # create images
     template = (make_circle((64, 64), np.array([25, 35]), 15) * 0.2
-              + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
+                + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
     target = (make_circle((64, 64), np.array([35, 25]), 15) * 0.2
               + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2, gamma=1.)
-    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD')
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
+    result = gs.register(template, target, sigma=0.01, return_all=True)
 
     result['initial_vector_field'].save_tikz('initial_vector_field_translation.tex',
                                              title="Initial vector field translation",

--- a/examples/geodesic_shooting/translation_example.py
+++ b/examples/geodesic_shooting/translation_example.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
               + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1, gamma=1.)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
     result['initial_vector_field'].save_tikz('initial_vector_field_translation.tex',

--- a/examples/regularizer/solution_pde_1d.py
+++ b/examples/regularizer/solution_pde_1d.py
@@ -1,0 +1,51 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.sparse as sps
+
+from geodesic_shooting.utils.regularizer import BiharmonicRegularizer
+
+
+N = 1000
+x_vals = np.linspace(0, 1, N)
+assert len(x_vals) == N
+
+alpha = 0.5
+exponent = 1
+gamma = 10.
+
+A = (np.diag((gamma + alpha * 2. * (N - 1) ** 2) * np.ones(N))
+     + np.diag(-alpha * (N - 1) ** 2 * np.ones(N - 1), 1)
+     + np.diag(-alpha * (N - 1) ** 2 * np.ones(N - 1), -1))
+b = x_vals
+
+y_vals = np.linalg.solve(A, b)
+plt.plot(x_vals, y_vals)
+plt.grid()
+plt.show()
+
+regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False)
+regularizer.init_matrices((N, ))
+
+A2 = regularizer.helmholtz_matrix
+y_vals_2 = sps.linalg.spsolve(A2, b)
+assert np.allclose(y_vals, y_vals_2)
+assert np.linalg.norm(A2 @ y_vals_2 - b) < 1e-10
+plt.plot(x_vals, y_vals_2)
+plt.grid()
+plt.show()
+
+A3 = regularizer.cauchy_navier_matrix
+y_vals_3 = sps.linalg.spsolve(A3, b)
+y_vals_check = np.linalg.solve(A, y_vals)
+assert np.allclose(y_vals_3, y_vals_check)
+assert np.linalg.norm(A3 @ y_vals_3 - b) < 1e-5
+plt.plot(x_vals, y_vals_3)
+plt.grid()
+plt.show()
+
+y_vals_4 = regularizer.lu_decomposed_cauchy_navier_matrix.solve(b)
+assert np.allclose(y_vals_4, y_vals_check)
+assert np.linalg.norm(A3 @ y_vals_4 - b) < 1e-5
+plt.plot(x_vals, y_vals_4)
+plt.grid()
+plt.show()

--- a/examples/regularizer/solution_pde_2d.py
+++ b/examples/regularizer/solution_pde_2d.py
@@ -1,0 +1,57 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.sparse as sps
+import time
+
+from geodesic_shooting.core import VectorField
+from geodesic_shooting.utils.regularizer import BiharmonicRegularizer
+
+
+N = 50
+x_vals = np.linspace(0, 1, N)
+assert len(x_vals) == N
+
+alpha = 0.5
+exponent = 1
+gamma = 1.
+
+b = np.ones(N**2)
+
+regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False)
+regularizer.init_matrices((N, N))
+
+A2 = regularizer.cauchy_navier_matrix
+
+tic = time.perf_counter()
+u, info = sps.linalg.cg(A2, b)
+print(f"Time CG: {time.perf_counter() - tic}")
+assert info == 0
+tic = time.perf_counter()
+u2 = regularizer.lu_decomposed_cauchy_navier_matrix.solve(b)
+print(f"Time with precomputed LU: {time.perf_counter() - tic}")
+assert np.allclose(u, u2)
+
+u_square = np.reshape(u, [N, N])
+
+levels = None
+plt.contourf(u_square, levels=levels)
+plt.colorbar()
+plt.show()
+
+data = np.zeros((N, N, 2))
+data[..., 0] = 1.
+data[..., 1] = 2.
+v = VectorField(data=data)
+v.plot()
+u = regularizer.cauchy_navier_inverse(v)
+
+levels = None
+plt.contourf(u.to_numpy()[..., 0], levels=levels)
+plt.colorbar()
+plt.show()
+assert np.allclose(u_square, u.to_numpy()[..., 0])
+
+plt.contourf(u.to_numpy()[..., 1], levels=levels)
+plt.colorbar()
+plt.show()
+assert np.allclose(2. * u_square, u.to_numpy()[..., 1])

--- a/geodesic_shooting/core/functions.py
+++ b/geodesic_shooting/core/functions.py
@@ -97,7 +97,8 @@ class ScalarFunction(BaseFunction):
 
         if created_figure:
             if colorbar:
-                fig.colorbar(vals, ax=axis)
+                if not isinstance(vals, list):
+                    fig.colorbar(vals, ax=axis)
             return fig, axis, vals
         return axis, vals
 

--- a/geodesic_shooting/core/vector_fields.py
+++ b/geodesic_shooting/core/vector_fields.py
@@ -164,11 +164,12 @@ class VectorField(BaseFunction):
             if vmin and vmax:
                 clim = (vmin, vmax)
             if self.dim == 1:
+                print("Colored quiver plot in 1d not available!")
                 vals = axis.quiver(identity_grid[::interval, 0] / (self.spatial_shape[0] - 1),
                                    np.zeros(self.spatial_shape),
                                    self[::interval, 0],
                                    np.zeros(self.spatial_shape),
-                                   colors=colors, scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
+                                   scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
                                    clim=clim)
             elif self.dim == 2:
                 vals = axis.quiver(identity_grid[::interval, ::interval, 0] / (self.spatial_shape[0] - 1),

--- a/geodesic_shooting/core/vector_fields.py
+++ b/geodesic_shooting/core/vector_fields.py
@@ -165,22 +165,27 @@ class VectorField(BaseFunction):
                 clim = (vmin, vmax)
             if self.dim == 1:
                 vals = axis.quiver(identity_grid[::interval, 0] / (self.spatial_shape[0] - 1),
-                                   np.zeros(self.spatial_shape), self[::interval, 0], np.zeros(self.spatial_shape),
-                                   colors, scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
+                                   np.zeros(self.spatial_shape),
+                                   self[::interval, 0],
+                                   np.zeros(self.spatial_shape),
+                                   colors=colors, scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
                                    clim=clim)
             elif self.dim == 2:
                 vals = axis.quiver(identity_grid[::interval, ::interval, 0] / (self.spatial_shape[0] - 1),
                                    identity_grid[::interval, ::interval, 1] / (self.spatial_shape[1] - 1),
-                                   self[::interval, ::interval, 0], self[::interval, ::interval, 1], colors,
-                                   scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder, clim=clim)
+                                   self[::interval, ::interval, 0],
+                                   self[::interval, ::interval, 1],
+                                   colors=colors, scale_units='xy', units='xy', angles='xy', scale=scale,
+                                   zorder=zorder, clim=clim)
             elif self.dim == 3:
+                print("Colored quiver plot in 3d not available!")
                 vals = axis.quiver(identity_grid[::interval, ::interval, ::interval, 0] / (self.spatial_shape[0] - 1),
                                    identity_grid[::interval, ::interval, ::interval, 1] / (self.spatial_shape[1] - 1),
                                    identity_grid[::interval, ::interval, ::interval, 2] / (self.spatial_shape[2] - 1),
                                    self[::interval, ::interval, ::interval, 0],
                                    self[::interval, ::interval, ::interval, 1],
                                    self[::interval, ::interval, ::interval, 2],
-                                   colors=colors, zorder=zorder, clim=clim)
+                                   zorder=zorder)
             if colorbar and created_figure:
                 fig.colorbar(vals, ax=axis)
         else:

--- a/geodesic_shooting/core/vector_fields.py
+++ b/geodesic_shooting/core/vector_fields.py
@@ -59,7 +59,7 @@ class VectorField(BaseFunction):
         -------
         The angle as a `ScalarFunction`.
         """
-        return ScalarFunction(data=np.arctan(self.copy().to_numpy()[..., 1], self.copy().to_numpy()[..., 0]))
+        return ScalarFunction(data=np.arctan2(self.copy().to_numpy()[..., 1], self.copy().to_numpy()[..., 0]))
 
     def get_component_as_function(self, component=0):
         """Provides the specified component of the `VectorField` as a `ScalarFunction`.

--- a/geodesic_shooting/core/vector_fields.py
+++ b/geodesic_shooting/core/vector_fields.py
@@ -164,19 +164,18 @@ class VectorField(BaseFunction):
             if vmin and vmax:
                 clim = (vmin, vmax)
             if self.dim == 1:
-                print("Colored quiver plot in 1d not available!")
                 vals = axis.quiver(identity_grid[::interval, 0] / (self.spatial_shape[0] - 1),
                                    np.zeros(self.spatial_shape),
                                    self[::interval, 0],
                                    np.zeros(self.spatial_shape),
-                                   scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
+                                   colors, scale_units='xy', units='xy', angles='xy', scale=scale, zorder=zorder,
                                    clim=clim)
             elif self.dim == 2:
                 vals = axis.quiver(identity_grid[::interval, ::interval, 0] / (self.spatial_shape[0] - 1),
                                    identity_grid[::interval, ::interval, 1] / (self.spatial_shape[1] - 1),
                                    self[::interval, ::interval, 0],
                                    self[::interval, ::interval, 1],
-                                   colors=colors, scale_units='xy', units='xy', angles='xy', scale=scale,
+                                   colors, scale_units='xy', units='xy', angles='xy', scale=scale,
                                    zorder=zorder, clim=clim)
             elif self.dim == 3:
                 print("Colored quiver plot in 3d not available!")

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -165,12 +165,13 @@ class GeodesicShooting:
                 # to the initial vector field
                 gradient_initial_vector = self.integrate_backward_adjoint_Jacobi_field(gradient_l2_energy,
                                                                                        vector_fields)
+                gradient_initial_vector = gradient_initial_vector.to_numpy().flatten()
 
                 if return_all_energies:
                     return energy, energy_regularizer, energy_intensity_unscaled, energy_intensity, \
-                            gradient_initial_vector.to_numpy().flatten()
+                            gradient_initial_vector
                 else:
-                    return energy, gradient_initial_vector.to_numpy().flatten()
+                    return energy, gradient_initial_vector
             else:
                 if return_all_energies:
                     return energy, energy_regularizer, energy_intensity_unscaled, energy_intensity

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -183,7 +183,7 @@ class GeodesicShooting:
             opt['x'] = x
 
         # use scipy optimizer for minimizing energy function
-        with self.logger.block("Perform image matching via geodesic shooting ..."):
+        with self.logger.block('Perform image matching via geodesic shooting ...'):
             if optimization_method == 'GD':
                 def gradient_descent(func, x0, grad_norm_tol=1e-5, rel_func_update_tol=1e-6, maxiter=1000,
                                      maxiter_armijo=20, alpha0=1., rho=0.5, c1=1e-4, disp=True, callback=None):
@@ -199,6 +199,9 @@ class GeodesicShooting:
                             alpha *= rho
                             func_x_update = func(x + alpha * d, compute_grad=False)
                             k += 1
+                        if not func_x_update <= func_x + c1 * alpha * d_dot_grad:
+                            alpha = 0.
+                            self.logger.warning('No step size that fulfills the decrease condition was found!')
                         return alpha
 
                     message = ''

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -119,7 +119,7 @@ class GeodesicShooting:
         def compute_grad_energy(image):
             grad_diff = image.grad * (image - target)[..., np.newaxis]
             grad_diff[inverse_mask] = 0.
-            return VectorField(data=2. * self.regularizer.cauchy_navier_inverse(grad_diff))
+            return 2. * self.regularizer.cauchy_navier_inverse(grad_diff)
 
         # set up variables
         self.shape = template.spatial_shape

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -59,7 +59,7 @@ class GeodesicShooting:
                 f"\tTime steps: {self.time_steps}\n"
                 f"\tSampler options: {self.sampler_options}")
 
-    def register(self, template, target, sigma=0.1, optimization_method='L-BFGS-B', optimizer_options={'disp': True},
+    def register(self, template, target, sigma=0.1, optimization_method='GD', optimizer_options={'disp': True},
                  initial_vector_field=None, restriction=np.s_[...], return_all=False, log_summary=True):
         """Performs actual registration according to LDDMM algorithm with time-varying vector
            fields that are chosen via geodesics.

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -16,8 +16,9 @@ class GeodesicShooting:
     Geodesic Shooting for Computational Anatomy.
     Miller, Trouvé, Younes, 2006
     """
-    def __init__(self, alpha=0.1, exponent=1, gamma=1., time_integrator=RK4, time_steps=30, fourier=True,
-                 sampler_options={'order': 1, 'mode': 'edge'}, log_level='INFO'):
+    def __init__(self, alpha=0.1, exponent=1, gamma=1., time_integrator=RK4, time_steps=30,
+                 fourier=False, spatial_shape=None, sampler_options={'order': 1, 'mode': 'edge'},
+                 log_level='INFO'):
         """Constructor.
 
         Parameters
@@ -35,7 +36,7 @@ class GeodesicShooting:
         log_level
             Verbosity of the logger.
         """
-        self.regularizer = BiharmonicRegularizer(alpha, exponent, gamma, fourier=fourier)
+        self.regularizer = BiharmonicRegularizer(alpha, exponent, gamma, fourier=fourier, spatial_shape=spatial_shape)
 
         self.time_integrator = time_integrator
         self.time_steps = time_steps
@@ -97,6 +98,8 @@ class GeodesicShooting:
         assert isinstance(template, ScalarFunction)
         assert isinstance(target, ScalarFunction)
         assert template.full_shape == target.full_shape
+
+        self.regularizer.init_matrices(template.spatial_shape)
 
         inverse_mask = np.ones(template.spatial_shape, bool)
         inverse_mask[restriction] = 0

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -16,7 +16,7 @@ class GeodesicShooting:
     Geodesic Shooting for Computational Anatomy.
     Miller, Trouvé, Younes, 2006
     """
-    def __init__(self, alpha=0.1, exponent=1, gamma=1., time_integrator=RK4, time_steps=30,
+    def __init__(self, alpha=0.1, exponent=1, gamma=1., time_integrator=RK4, time_steps=30, fourier=True,
                  sampler_options={'order': 1, 'mode': 'edge'}, log_level='INFO'):
         """Constructor.
 
@@ -35,7 +35,7 @@ class GeodesicShooting:
         log_level
             Verbosity of the logger.
         """
-        self.regularizer = BiharmonicRegularizer(alpha, exponent, gamma)
+        self.regularizer = BiharmonicRegularizer(alpha, exponent, gamma, fourier=fourier)
 
         self.time_integrator = time_integrator
         self.time_steps = time_steps

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -59,7 +59,7 @@ class GeodesicShooting:
                 f"\tTime steps: {self.time_steps}\n"
                 f"\tSampler options: {self.sampler_options}")
 
-    def register(self, template, target, sigma=0.1, optimization_method='GD', optimizer_options={'disp': True},
+    def register(self, template, target, sigma=0.01, optimization_method='GD', optimizer_options={'disp': True},
                  initial_vector_field=None, restriction=np.s_[...], return_all=False, log_summary=True):
         """Performs actual registration according to LDDMM algorithm with time-varying vector
            fields that are chosen via geodesics.
@@ -225,7 +225,10 @@ class GeodesicShooting:
                                     message = 'maximum number of iterations reached'
                                     break
 
-                                d = -grad_x
+                                if norm_grad_x > 1:
+                                    d = -grad_x / norm_grad_x
+                                else:
+                                    d = -grad_x
                                 alpha = line_search(x, func_x, grad_x, d)
                                 x = x + alpha * d
                                 func_x, grad_x = func(x)

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -27,10 +27,16 @@ class GeodesicShooting:
             Parameter for biharmonic regularizer.
         exponent
             Parameter for biharmonic regularizer.
+        gamma
+            Parameter for biharmonic regularizer.
         time_integrator
             Method to use for time integration.
         time_steps
             Number of time steps performed during forward and backward integration.
+        fourier
+            Parameter for biharmonic regularizer.
+        spatial_shape
+            Parameter for biharmonic regularizer.
         sampler_options
             Additional options to pass to the sampler.
         log_level

--- a/geodesic_shooting/geodesic_shooting.py
+++ b/geodesic_shooting/geodesic_shooting.py
@@ -324,7 +324,8 @@ class GeodesicShooting:
         self.logger.info("")
         self.logger.info("Registration summary")
         self.logger.info("====================")
-        self.logger.info(f"Registration finished after {results['iterations']} iteration{'' if results['iterations'] == 1 else 's'}.")
+        self.logger.info(f"Registration finished after {results['iterations']} iteration"
+                         f"{'' if results['iterations'] == 1 else 's'}.")
         self.logger.info(f"Registration took {results['time']} seconds.")
         self.logger.info(f"Reason for the registration algorithm to stop: {results['reason_registration_ended']}.")
         norm_difference = (results['target'] - results['transformed_input']).get_norm(restriction=restriction)

--- a/geodesic_shooting/utils/grad.py
+++ b/geodesic_shooting/utils/grad.py
@@ -33,7 +33,7 @@ def finite_difference(f):
         indices = list(range(dim))
         indices[0] = d
         indices[d] = 0
-        window_d = np.transpose(window / shape[d], axes=indices)
+        window_d = np.transpose(window, axes=indices) * shape[d]
         return correlate(u, window_d)
 
     derivatives = []

--- a/geodesic_shooting/utils/regularizer.py
+++ b/geodesic_shooting/utils/regularizer.py
@@ -59,7 +59,7 @@ class BiharmonicRegularizer:
             self.init_matrices(spatial_shape)
 
     def __str__(self):
-        return f"{self.__class__.__name__}: alpha={self.alpha}, exponent={self.exponent}"
+        return f"{self.__class__.__name__}: alpha={self.alpha}, exponent={self.exponent}, gamma={self.gamma}"
 
     def init_matrices(self, shape):
         """Initializes the Cauchy-Navier operator matrix and the LU decomposition of the matrix.

--- a/geodesic_shooting/utils/regularizer.py
+++ b/geodesic_shooting/utils/regularizer.py
@@ -22,13 +22,19 @@ class BiharmonicRegularizer:
         alpha
             Smoothness parameter that determines how strong the smoothing effect should be.
         exponent
+            Smoothness parameter that determines how strong the smoothing effect should be.
         gamma
+            Smoothness parameter that determines how strong the smoothing effect should be.
         fourier
             Determines whether to apply the regularizer in Fourier domain.
             If the regularizer is applied in Fourier domain, periodic boundary conditions
             are implicitly used. Otherwise, finite differences with homogeneous Dirichlet
             boundary conditions are applied.
+        spatial_shape
+            If `fourier` is False and `spatial_shape` provided, the matrices for the finite
+            difference scheme are automatically initialized.
         log_level
+            Verbosity of the logger.
         """
         assert alpha >= 0
         assert exponent > 0
@@ -56,7 +62,7 @@ class BiharmonicRegularizer:
         return f"{self.__class__.__name__}: alpha={self.alpha}, exponent={self.exponent}"
 
     def init_matrices(self, shape):
-        """Initializes the Cauchy-Navier operator matrix and inverse matrices.
+        """Initializes the Cauchy-Navier operator matrix and the LU decomposition of the matrix.
 
         Parameters
         ----------

--- a/geodesic_shooting/utils/summary.py
+++ b/geodesic_shooting/utils/summary.py
@@ -61,7 +61,8 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
     plt.title("Singular values of time-evolution of the vector field")
     plt.show()
 
-    results['initial_vector_field'].plot("Initial vector field", interval=interval, scale=scale, figsize=figsize)
+    results['initial_vector_field'].plot("Initial vector field", interval=interval, scale=scale, color_length=True,
+                                         figsize=figsize)
     plt.show()
 
     results['initial_vector_field'].get_magnitude().plot("Magnitude of initial vector field", figsize=figsize)
@@ -70,7 +71,10 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
     results['initial_vector_field'].get_angle().plot("Angle of initial vector field", figsize=figsize)
     plt.show()
 
-    fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
+    if results['input'].dim == 3:
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize, subplot_kw = {'projection': '3d'})
+    else:
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
     ax1, vals1 = results['initial_vector_field'].plot("Initial vector field", axis=ax1, interval=interval,
                                                       scale=scale, color_length=True, figsize=figsize)
     if not isinstance(vals1, list):

--- a/geodesic_shooting/utils/summary.py
+++ b/geodesic_shooting/utils/summary.py
@@ -74,7 +74,7 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
         plt.show()
 
     if dim == 3:
-        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize, subplot_kw = {'projection': '3d'})
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize, subplot_kw={'projection': '3d'})
     else:
         fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
     ax1, vals1 = results['initial_vector_field'].plot("Initial vector field", axis=ax1, interval=interval,

--- a/geodesic_shooting/utils/summary.py
+++ b/geodesic_shooting/utils/summary.py
@@ -24,8 +24,9 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
         Determines whether to also visualize the boundary of the domain restriction.
     """
     diffeomorphism = results['flow']
+    dim = results['input'].dim
 
-    if results['input'].dim == 3:
+    if dim == 3:
         fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, subplot_kw={'projection': '3d'})
     else:
         fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4)
@@ -68,10 +69,11 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
     results['initial_vector_field'].get_magnitude().plot("Magnitude of initial vector field", figsize=figsize)
     plt.show()
 
-    results['initial_vector_field'].get_angle().plot("Angle of initial vector field", figsize=figsize)
-    plt.show()
+    if dim > 1:
+        results['initial_vector_field'].get_angle().plot("Angle of initial vector field", figsize=figsize)
+        plt.show()
 
-    if results['input'].dim == 3:
+    if dim == 3:
         fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize, subplot_kw = {'projection': '3d'})
     else:
         fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=figsize)
@@ -83,10 +85,11 @@ def plot_registration_results(results, interval=1, frequency=1, scale=None, figs
                                                                       axis=ax2, figsize=figsize)
     if not isinstance(vals2, list):
         fig.colorbar(vals2, ax=ax2, fraction=0.046, pad=0.04)
-    ax3, vals3 = results['initial_vector_field'].get_angle().plot("Angle of initial vector field",
-                                                                  axis=ax3, figsize=figsize)
-    if not isinstance(vals3, list):
-        fig.colorbar(vals3, ax=ax3, fraction=0.046, pad=0.04)
+    if dim > 1:
+        ax3, vals3 = results['initial_vector_field'].get_angle().plot("Angle of initial vector field",
+                                                                      axis=ax3, figsize=figsize)
+        if not isinstance(vals3, list):
+            fig.colorbar(vals3, ax=ax3, fraction=0.046, pad=0.04)
     plt.show()
 
     if results['initial_vector_field'].dim == 2:

--- a/tests/test_3d_geodesic_shooting.py
+++ b/tests/test_3d_geodesic_shooting.py
@@ -8,8 +8,8 @@ def test_3d_geodesic_shooting():
     shape = (10, 10, 10)
     template = np.zeros(shape)
     target = np.zeros(shape)
-    template[shape[0]//5:2*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:2*shape[2]//5] = 1
-    target[shape[0]//5:3*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:3*shape[2]//5] = 1
+    template[2*shape[0]//5:3*shape[0]//5, 2*shape[1]//5:3*shape[1]//5, 2*shape[2]//5:3*shape[2]//5] = 1
+    target[2*shape[0]//5:3*shape[0]//5, 3*shape[1]//5:4*shape[1]//5, 2*shape[2]//5:3*shape[2]//5] = 1
     template = ScalarFunction(data=template)
     target = ScalarFunction(data=target)
 

--- a/tests/test_3d_geodesic_shooting.py
+++ b/tests/test_3d_geodesic_shooting.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import geodesic_shooting
 from geodesic_shooting.core import ScalarFunction
-from geodesic_shooting.utils.summary import plot_registration_results
 
 
 def test_3d_geodesic_shooting():

--- a/tests/test_3d_geodesic_shooting.py
+++ b/tests/test_3d_geodesic_shooting.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+import geodesic_shooting
+from geodesic_shooting.core import ScalarFunction
+from geodesic_shooting.utils.summary import plot_registration_results
+
+
+def test_3d_geodesic_shooting():
+    shape = (10, 10, 10)
+    template = np.zeros(shape)
+    target = np.zeros(shape)
+    template[shape[0]//5:2*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:2*shape[2]//5] = 1
+    target[shape[0]//5:3*shape[0]//5, shape[1]//5:2*shape[1]//5, shape[2]//5:3*shape[2]//5] = 1
+    template = ScalarFunction(data=template)
+    target = ScalarFunction(data=target)
+
+    # perform the registration
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
+    result = gs.register(template, target, sigma=0.01, return_all=True)
+
+    assert (target - result['transformed_input']).norm / target.norm < 1e-2

--- a/tests/test_circle_scaling.py
+++ b/tests/test_circle_scaling.py
@@ -10,7 +10,7 @@ def test_circle_scaling():
     target = make_circle((64, 64), np.array([32, 32]), 20)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.05, exponent=1, gamma=5.)
     result = gs.register(template, target, sigma=0.01, return_all=True,
                          optimizer_options={'disp': True, 'maxiter': 20})
 

--- a/tests/test_circle_scaling.py
+++ b/tests/test_circle_scaling.py
@@ -11,6 +11,7 @@ def test_circle_scaling():
 
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
-    result = gs.register(template, target, sigma=0.01, return_all=True, optimizer_options={'disp': True, 'maxiter': 20})
+    result = gs.register(template, target, sigma=0.01, return_all=True,
+                         optimizer_options={'disp': True, 'maxiter': 20})
 
     assert (target - result['transformed_input']).norm / target.norm < 5e-2

--- a/tests/test_circle_to_square.py
+++ b/tests/test_circle_to_square.py
@@ -10,8 +10,8 @@ def test_circle_to_square():
     target = make_square((64, 64), np.array([32, 32]), 40)
 
     # perform the registration
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, gamma=5.)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1, gamma=5.)
     result = gs.register(template, target, sigma=0.01, return_all=True,
                          optimizer_options={'maxiter': 50, 'grad_norm_tol': 1e-3})
 
-    assert (target - result['transformed_input']).norm / target.norm < 5e-2
+    assert (target - result['transformed_input']).norm / target.norm < 1e-2

--- a/tests/test_circle_to_square.py
+++ b/tests/test_circle_to_square.py
@@ -11,7 +11,7 @@ def test_circle_to_square():
 
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1, gamma=5.)
-    result = gs.register(template, target, sigma=0.01, return_all=True, optimization_method='GD',
+    result = gs.register(template, target, sigma=0.01, return_all=True,
                          optimizer_options={'maxiter': 50, 'grad_norm_tol': 1e-3})
 
     assert (target - result['transformed_input']).norm / target.norm < 5e-2

--- a/tests/test_epdiff.py
+++ b/tests/test_epdiff.py
@@ -11,11 +11,12 @@ def test_epdiff_constant_vector_field():
     def f(x, y):
         return np.stack([2.*np.ones_like(x), 2.*np.ones_like(x)], axis=-1)
 
-    grid_x, grid_y = np.meshgrid(np.linspace(0, 1, shape[0]), np.linspace(0, 1, shape[1]), indexing='ij')
+    grid_x, grid_y = np.meshgrid(np.linspace(0, 1, shape[0]), np.linspace(0, 1, shape[1]),
+                                 indexing='ij')
 
     displacement_field = VectorField(data=f(grid_x, grid_y))
     time_steps = 5
 
-    gs = geodesic_shooting.GeodesicShooting(time_steps=time_steps)
+    gs = geodesic_shooting.GeodesicShooting(time_steps=time_steps, fourier=True)
     time_dependent_field = gs.integrate_forward_vector_field(displacement_field)
     assert all([np.isclose((time_dependent_field[t] - displacement_field).norm, 0.) for t in range(time_steps)])

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -11,15 +11,15 @@ def test_grad():
     f1 = ScalarFunction(shape)
     f1[..., 2] = 1
     derivative = VectorField(shape)
-    derivative[:, 1, 1] = 0.5 / shape[1]
-    derivative[:, 3, 1] = -0.5 / shape[1]
+    derivative[:, 1, 1] = 0.5 * shape[1]
+    derivative[:, 3, 1] = -0.5 * shape[1]
     assert finite_difference(f1) == derivative
 
     f2 = ScalarFunction(shape)
     f2[2, ...] = 1
     derivative = VectorField(shape)
-    derivative[1, :, 0] = 0.5 / shape[0]
-    derivative[3, :, 0] = -0.5 / shape[0]
+    derivative[1, :, 0] = 0.5 * shape[0]
+    derivative[3, :, 0] = -0.5 * shape[0]
     assert finite_difference(f2) == derivative
 
     v = VectorField(shape)

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from geodesic_shooting.utils.regularizer import BiharmonicRegularizer
 from geodesic_shooting.core import VectorField
@@ -14,3 +15,32 @@ def test_regularizer_self_adjoint():
     wLv = w.to_numpy().flatten().dot(regularizer.cauchy_navier(v).to_numpy().flatten())
     vLw = v.to_numpy().flatten().dot(regularizer.cauchy_navier(w).to_numpy().flatten())
     assert np.isclose(wLv, vLw)
+
+
+@pytest.mark.parametrize("alpha", [1., 0.1, 0.01])
+@pytest.mark.parametrize("exponent", [1])
+@pytest.mark.parametrize("gamma", [10., 1., 0.1])
+@pytest.mark.parametrize("dim", [1, 2])
+@pytest.mark.parametrize("size_per_dimension", [10, 20])
+def test_regularizer_matrices(alpha, exponent, gamma, dim, size_per_dimension):
+    regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False)
+    regularizer.init_matrices(tuple([size_per_dimension] * dim))
+
+    assert np.allclose(regularizer.helmholtz_matrix, regularizer.helmholtz_matrix.T)
+    assert regularizer.helmholtz_matrix.shape == (size_per_dimension**dim * dim, size_per_dimension**dim * dim)
+    if dim == 1:
+        assert np.isclose(regularizer.helmholtz_matrix[0, 0], gamma + alpha * 2. * (size_per_dimension - 1) ** 2)
+        assert np.isclose(regularizer.helmholtz_matrix[0, 1], -alpha * (size_per_dimension - 1) ** 2)
+        assert np.isclose(regularizer.helmholtz_matrix[1, 0], -alpha * (size_per_dimension - 1) ** 2)
+        assert np.allclose(regularizer.helmholtz_matrix,
+                           np.diag((gamma + alpha * 2. * (size_per_dimension - 1) ** 2) * np.ones(size_per_dimension))
+                           + np.diag(-alpha * (size_per_dimension - 1) ** 2 * np.ones(size_per_dimension - 1), 1)
+                           + np.diag(-alpha * (size_per_dimension - 1) ** 2 * np.ones(size_per_dimension - 1), -1))
+    elif dim == 2:
+        assert np.allclose(regularizer.helmholtz_matrix[:size_per_dimension**2, :size_per_dimension**2],
+                           regularizer.helmholtz_matrix[size_per_dimension**2:, size_per_dimension**2:])
+        assert np.allclose(regularizer.helmholtz_matrix[:size_per_dimension**2, size_per_dimension**2:],
+                           np.zeros((size_per_dimension**2, size_per_dimension**2)))
+        assert np.allclose(regularizer.helmholtz_matrix[size_per_dimension**2:, :size_per_dimension**2],
+                           np.zeros((size_per_dimension**2, size_per_dimension**2)))
+        assert np.isclose(regularizer.helmholtz_matrix[0, 0], gamma * 1 + alpha * 4. * (size_per_dimension - 1) ** 2)

--- a/tests/test_regularizer.py
+++ b/tests/test_regularizer.py
@@ -26,21 +26,17 @@ def test_regularizer_matrices(alpha, exponent, gamma, dim, size_per_dimension):
     regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False)
     regularizer.init_matrices(tuple([size_per_dimension] * dim))
 
-    assert np.allclose(regularizer.helmholtz_matrix, regularizer.helmholtz_matrix.T)
-    assert regularizer.helmholtz_matrix.shape == (size_per_dimension**dim * dim, size_per_dimension**dim * dim)
+    assert np.allclose(regularizer.helmholtz_matrix.toarray(), regularizer.helmholtz_matrix.T.toarray())
+    assert regularizer.helmholtz_matrix.shape == (size_per_dimension**dim, size_per_dimension**dim)
     if dim == 1:
         assert np.isclose(regularizer.helmholtz_matrix[0, 0], gamma + alpha * 2. * (size_per_dimension - 1) ** 2)
         assert np.isclose(regularizer.helmholtz_matrix[0, 1], -alpha * (size_per_dimension - 1) ** 2)
         assert np.isclose(regularizer.helmholtz_matrix[1, 0], -alpha * (size_per_dimension - 1) ** 2)
-        assert np.allclose(regularizer.helmholtz_matrix,
+        assert np.allclose(regularizer.helmholtz_matrix.toarray(),
                            np.diag((gamma + alpha * 2. * (size_per_dimension - 1) ** 2) * np.ones(size_per_dimension))
                            + np.diag(-alpha * (size_per_dimension - 1) ** 2 * np.ones(size_per_dimension - 1), 1)
                            + np.diag(-alpha * (size_per_dimension - 1) ** 2 * np.ones(size_per_dimension - 1), -1))
     elif dim == 2:
-        assert np.allclose(regularizer.helmholtz_matrix[:size_per_dimension**2, :size_per_dimension**2],
-                           regularizer.helmholtz_matrix[size_per_dimension**2:, size_per_dimension**2:])
-        assert np.allclose(regularizer.helmholtz_matrix[:size_per_dimension**2, size_per_dimension**2:],
-                           np.zeros((size_per_dimension**2, size_per_dimension**2)))
-        assert np.allclose(regularizer.helmholtz_matrix[size_per_dimension**2:, :size_per_dimension**2],
-                           np.zeros((size_per_dimension**2, size_per_dimension**2)))
         assert np.isclose(regularizer.helmholtz_matrix[0, 0], gamma * 1 + alpha * 4. * (size_per_dimension - 1) ** 2)
+        assert np.isclose(regularizer.helmholtz_matrix[0, 1], -alpha * (size_per_dimension - 1) ** 2)
+        assert np.isclose(regularizer.helmholtz_matrix[1, 0], -alpha * (size_per_dimension - 1) ** 2)

--- a/tests/test_regularizer_solution_pde.py
+++ b/tests/test_regularizer_solution_pde.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from geodesic_shooting.utils.regularizer import BiharmonicRegularizer
+
+
+@pytest.mark.parametrize("N", [10, 100, 1000])
+@pytest.mark.parametrize("alpha", [0.01, 0.1, 0.5])
+@pytest.mark.parametrize("exponent", [1])
+@pytest.mark.parametrize("gamma", [5., 10.])
+def test_regularizer_as_PDE_solver_1d(N, alpha, exponent, gamma):
+    x_vals = np.linspace(0, 1, N)
+    assert len(x_vals) == N
+
+    A = (np.diag((gamma + alpha * 2. * (N - 1) ** 2) * np.ones(N))
+         + np.diag(-alpha * (N - 1) ** 2 * np.ones(N - 1), 1)
+         + np.diag(-alpha * (N - 1) ** 2 * np.ones(N - 1), -1))
+    A = np.linalg.matrix_power(A, exponent)
+    b = x_vals
+
+    y_vals = np.linalg.solve(A, b)
+
+    regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False, spatial_shape=(N, ))
+
+    A2 = regularizer.helmholtz_matrix
+    y_vals_2 = sps.linalg.spsolve(A2, b)
+    assert np.allclose(y_vals, y_vals_2)
+    assert np.linalg.norm(A2 @ y_vals_2 - b) < 1e-9
+
+    A3 = regularizer.cauchy_navier_matrix
+    y_vals_3 = sps.linalg.spsolve(A3, b)
+    y_vals_check = np.linalg.solve(A, y_vals)
+    assert np.allclose(y_vals_3, y_vals_check)
+    assert np.linalg.norm(A3 @ y_vals_3 - b) < 5e-5
+
+    y_vals_4 = regularizer.lu_decomposed_cauchy_navier_matrix.solve(b)
+    assert np.allclose(y_vals_4, y_vals_check)
+    assert np.linalg.norm(A3 @ y_vals_4 - b) < 5e-5

--- a/tests/test_regularizer_solution_pde_2d.py
+++ b/tests/test_regularizer_solution_pde_2d.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from geodesic_shooting.core import VectorField
+from geodesic_shooting.utils.regularizer import BiharmonicRegularizer
+
+
+@pytest.mark.parametrize("N", [10, 50])
+@pytest.mark.parametrize("alpha", [0.01, 0.1, 0.5])
+@pytest.mark.parametrize("exponent", [1])
+@pytest.mark.parametrize("gamma", [1., 5., 10.])
+def test_regularizer_as_PDE_solver_2d(N, alpha, exponent, gamma):
+    x_vals = np.linspace(0, 1, N)
+    assert len(x_vals) == N
+
+    b = np.ones(N**2)
+
+    regularizer = BiharmonicRegularizer(alpha=alpha, exponent=exponent, gamma=gamma, fourier=False)
+    regularizer.init_matrices((N, N))
+
+    A2 = regularizer.cauchy_navier_matrix
+    u, info = sps.linalg.cg(A2, b)
+    assert info == 0
+    u2 = regularizer.lu_decomposed_cauchy_navier_matrix.solve(b)
+    assert np.allclose(u, u2)
+
+    u_square = np.reshape(u, [N, N])
+
+    data = np.zeros((N, N, 2))
+    data[..., 0] = 1.
+    data[..., 1] = 2.
+    v = VectorField(data=data)
+    u = regularizer.cauchy_navier_inverse(v)
+    assert np.allclose(u_square, u.to_numpy()[..., 0])
+    assert np.allclose(2. * u_square, u.to_numpy()[..., 1])

--- a/tests/test_square_to_circle.py
+++ b/tests/test_square_to_circle.py
@@ -14,7 +14,8 @@ def test_square_to_circle():
 
     # perform the registration
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=1)
-    result = gs.register(template, target, sigma=0.01, return_all=True, restriction=restriction)
+    result = gs.register(template, target, sigma=0.01, return_all=True, restriction=restriction,
+                         optimizer_options={'disp': True, 'maxiter': 100})
 
     norm_difference = (target - result['transformed_input']).get_norm(restriction=restriction)
-    assert norm_difference / target.get_norm(restriction=restriction) < 1e-2
+    assert norm_difference / target.get_norm(restriction=restriction) < 5e-2

--- a/tests/test_square_to_circle.py
+++ b/tests/test_square_to_circle.py
@@ -17,4 +17,4 @@ def test_square_to_circle():
     result = gs.register(template, target, sigma=0.01, return_all=True, restriction=restriction)
 
     norm_difference = (target - result['transformed_input']).get_norm(restriction=restriction)
-    assert norm_difference / target.get_norm(restriction=restriction) < 1e-1
+    assert norm_difference / target.get_norm(restriction=restriction) < 1e-2

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -12,7 +12,7 @@ def test_translation():
               + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration with the geodesic shooting algorithm
-    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.1, exponent=1)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
     assert (target - result['transformed_input']).norm / target.norm < 1e-1

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -15,7 +15,7 @@ def test_translation():
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
-    assert (target - result['transformed_input']).norm / target.norm < 1e-2
+    assert (target - result['transformed_input']).norm / target.norm < 5e-2
 
     # create images
     template = make_square((64, 64), np.array([24, 24]), 40)
@@ -25,4 +25,4 @@ def test_translation():
     gs = geodesic_shooting.GeodesicShooting(alpha=1., exponent=2)
     result = gs.register(template, target, sigma=0.1, return_all=True)
 
-    assert (target - result['transformed_input']).norm / target.norm < 1e-2
+    assert (target - result['transformed_input']).norm / target.norm < 5e-2

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -7,7 +7,7 @@ from geodesic_shooting.utils.create_example_images import make_circle, make_squa
 def test_translation():
     # create images
     template = (make_circle((64, 64), np.array([25, 35]), 15) * 0.2
-              + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
+                + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
     target = (make_circle((64, 64), np.array([35, 25]), 15) * 0.2
               + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -6,14 +6,14 @@ from geodesic_shooting.utils.create_example_images import make_circle, make_squa
 
 def test_translation():
     # create images
-    template = (make_circle((64, 64), np.array([25, 40]), 18) * 0.2
-              + make_circle((64, 64), np.array([25, 40]), 15) * 0.8)
-    target = (make_circle((64, 64), np.array([40, 25]), 18) * 0.2
-              + make_circle((64, 64), np.array([40, 25]), 15) * 0.8)
+    template = (make_circle((64, 64), np.array([25, 35]), 15) * 0.2
+              + make_circle((64, 64), np.array([25, 35]), 12) * 0.8)
+    target = (make_circle((64, 64), np.array([35, 25]), 15) * 0.2
+              + make_circle((64, 64), np.array([35, 25]), 12) * 0.8)
 
     # perform the registration with the geodesic shooting algorithm
-    gs = geodesic_shooting.GeodesicShooting(alpha=1., exponent=2)
-    result = gs.register(template, target, sigma=0.1, return_all=True)
+    gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
+    result = gs.register(template, target, sigma=0.01, return_all=True)
 
     assert (target - result['transformed_input']).norm / target.norm < 1e-2
 

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -15,14 +15,4 @@ def test_translation():
     gs = geodesic_shooting.GeodesicShooting(alpha=0.01, exponent=2)
     result = gs.register(template, target, sigma=0.01, return_all=True)
 
-    assert (target - result['transformed_input']).norm / target.norm < 5e-2
-
-    # create images
-    template = make_square((64, 64), np.array([24, 24]), 40)
-    target = make_square((64, 64), np.array([40, 32]), 40)
-
-    # perform the registration with the geodesic shooting algorithm
-    gs = geodesic_shooting.GeodesicShooting(alpha=1., exponent=2)
-    result = gs.register(template, target, sigma=0.1, return_all=True)
-
-    assert (target - result['transformed_input']).norm / target.norm < 5e-2
+    assert (target - result['transformed_input']).norm / target.norm < 1e-1


### PR DESCRIPTION
This PR adds the option to use homogeneous Dirichlet boundary conditions for the vector fields instead of periodic boundary conditions implicitly given by working in Fourier domain.

The homogeneous Dirichlet boundary conditions are implemented using a finite difference scheme for the regularizer and explicitly enforcing zero boundary conditions. By using `scipy.sparse`, the implementation is made very fast and efficient.